### PR TITLE
Clean up resolvers when they throw an exception.

### DIFF
--- a/src/SOFe/AwaitStd/AwaitStd.php
+++ b/src/SOFe/AwaitStd/AwaitStd.php
@@ -37,7 +37,11 @@ final class AwaitStd {
 		$callback = yield;
 		$task = new ClosureTask(fn() => $callback());
 		$this->plugin->getScheduler()->scheduleDelayedTask($task, $ticks);
-		yield Await::ONCE;
+		try{
+			yield Await::ONCE;
+		}finally{
+			$task->getHandler()?->cancel();
+		}
 	}
 
 	/**


### PR DESCRIPTION
This is due to the new feature Await::safeRace() which will allow us to clean the resolvers easily.